### PR TITLE
override gitignore with npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules/*


### PR DESCRIPTION
ensures ./bin/* is fully published (.d.ts and .js.map)

fixes #2 