### PR TITLE
Minor Improvements

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -173,6 +173,10 @@ export enum ParameterFlags {
     Rest = 1 << 1
 }
 
+export const config = {
+    wrapJsDocComments: true,
+};
+
 export const create = {
     interface(name: string): InterfaceDeclaration {
         return {
@@ -484,13 +488,19 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
             newline();
         }
         if (decl.jsDocComment) {
-            start('/**');
-            newline();
-            for(const line of decl.jsDocComment.split(/\n/g)) {
-                start(` * ${line}`);
+            if (config.wrapJsDocComments) {
+                start('/**');
                 newline();
+                for(const line of decl.jsDocComment.split(/\n/g)) {
+                    start(` * ${line}`);
+                    newline();
+                }
+                start(' */');
             }
-            start(' */');
+            else {
+                start(decl.jsDocComment);
+            }
+
             newline();
         }
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -559,6 +559,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     print('[]');
                     break;
 
+                case "class":
                 case "interface":
                     print(e.name);
                     break;


### PR DESCRIPTION
Added a couple new features and a bug fix:

1. Implemented support for enums via `create.enum` and `create.enumValue`.
2. Fix support for class references when writing a type reference.
3. Add a new config object with a new option that changes the behavior of the jsdoc comment output.

The idea with this new config object is that if things come up in the future related to configuring the output in a global way, they can go here. I'm not crazy about this, and if you'd rather a new base value that just outputs above each write, instead of the new config for jsdoc I'm up for that.