### PR TITLE
More Improvements

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -175,6 +175,7 @@ export enum ParameterFlags {
 
 export const config = {
     wrapJsDocComments: true,
+    outputEol: '\r\n',
 };
 
 export const create = {
@@ -464,7 +465,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
     }
 
     function newline() {
-        output = output + '\r\n';
+        output = output + config.outputEol;
     }
 
     function needsParens(d: Type) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -399,6 +399,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
     let contextStack: ContextFlags[] = [rootFlags];
 
     writeDeclaration(rootDecl);
+    newline();
     return output;
 
     function getContextFlags() {
@@ -681,6 +682,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         indentLevel++;
         for (const m of c.members) {
             writeClassMember(m);
+            newline();
         }
         indentLevel--;
         start('}');
@@ -732,6 +734,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         indentLevel++;
         for (const member of ns.members) {
             writeDeclaration(member);
+            newline();
         }
         indentLevel--;
         start(`}`);
@@ -768,6 +771,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         indentLevel++;
         for (const member of m.members) {
             writeDeclaration(member);
+            newline();
         }
         indentLevel--;
         start(`}`);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -662,13 +662,13 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
 
     function writeClass(c: ClassDeclaration) {
         printDeclarationComments(c);
-        startWithDeclareOrExport(`${classFlagsToString(c.flags)}class ${c.name} `, c.flags);
+        startWithDeclareOrExport(`${classFlagsToString(c.flags)}class ${c.name}`, c.flags);
         if (c.baseType) {
-            print('extends ');
+            print(' extends ');
             writeReference(c.baseType);
         }
         if (c.implements && c.implements.length) {
-            print(`implements `);
+            print(' implements ');
             let first = true;
             for (const impl of c.implements) {
                 if (!first) print(', ');
@@ -676,7 +676,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                 first = false;
             }
         }
-        print('{');
+        print(' {');
         newline();
         indentLevel++;
         for (const m of c.members) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -492,7 +492,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
             if (config.wrapJsDocComments) {
                 start('/**');
                 newline();
-                for(const line of decl.jsDocComment.split(/\n/g)) {
+                for(const line of decl.jsDocComment.split(/\r?\n/g)) {
                     start(` * ${line}`);
                     newline();
                 }


### PR DESCRIPTION
A couple more bug fixes and features for you:

1. Added a config option for the output EOL used (I wanted \n, not \r\n).
2. Fixed a potential issue with jsDocComment by supporting windows line endings in the split.
3. Fixed spacing on classes when extending and implementing.
4. Added some extra whitespace to the ouput for readability.