### PR TITLE
Implement readonly & generics support

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -165,6 +165,7 @@ export enum DeclarationFlags {
     Export = 1 << 4,
     Abstract = 1 << 5,
     ExportDefault = 1 << 6,
+    ReadOnly = 1 << 7,
 }
 
 export enum ParameterFlags {
@@ -449,6 +450,10 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
             out += 'abstract ';
         }
 
+        if (flags & DeclarationFlags.ReadOnly) {
+            out += 'readonly ';
+        }
+
         return out;
     }
 
@@ -542,6 +547,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                 case 'property':
                     printDeclarationComments(member);
                     tab();
+                    if (member.flags & DeclarationFlags.ReadOnly) print('readonly ');
                     print(quoteIfNeeded(member.name));
                     if (member.flags & DeclarationFlags.Optional) print('?');
                     print(': ');


### PR DESCRIPTION
Implemented support for generics and readonly properties. Also fixed an issue where alias objects didn't write out their name when used as the type for a param/member.