### PR TITLE
fix: no const enum export

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -417,7 +417,7 @@ function quoteIfNeeded(s: string) {
     }
 }
 
-export const enum ContextFlags {
+export enum ContextFlags {
     None = 0,
     Module = 1 << 0,
     InAmbientNamespace = 1 << 1


### PR DESCRIPTION
To have the enums in the typings and as well in the transpiled code they
must not be declared as const.
This way we could work around a problem with wallaby:
https://github.com/wallabyjs/public/issues/1050#issuecomment-283280201