### PR TITLE
Add support for bare function signatures

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,7 +42,7 @@ export interface IndexSignature {
     valueType: Type;
 }
 
-export interface CallSignature {
+export interface CallSignature extends DeclarationBase {
     kind: "call-signature";
     parameters: Parameter[];
     returnType: Type;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -82,7 +82,7 @@ export interface ClassDeclaration extends DeclarationBase {
 export interface InterfaceDeclaration extends DeclarationBase {
     kind: "interface";
     name: string;
-    members: InterfaceMember[];
+    members: ObjectTypeMember[];
     baseTypes?: ObjectTypeReference[];
 }
 
@@ -130,7 +130,7 @@ export interface ModuleDeclaration extends DeclarationBase {
 
 export interface ObjectType {
     kind: "object";
-    members: InterfaceMember[];
+    members: ObjectTypeMember[];
 }
 
 export interface UnionType {
@@ -177,9 +177,8 @@ export type ThisType = "this";
 export type TypeReference = TopLevelDeclaration | NamedTypeReference | ArrayTypeReference | PrimitiveType;
 
 export type ObjectTypeReference = ClassDeclaration | InterfaceDeclaration;
-export type ObjectTypeMember = PropertyDeclaration | MethodDeclaration | IndexSignature;
-export type InterfaceMember = ObjectTypeMember | CallSignature;
-export type ClassMember = ObjectTypeMember | ConstructorDeclaration;
+export type ObjectTypeMember = PropertyDeclaration | MethodDeclaration | IndexSignature | CallSignature;
+export type ClassMember = PropertyDeclaration | MethodDeclaration | IndexSignature | ConstructorDeclaration;
 
 export type Type = TypeReference | UnionType | IntersectionType | PrimitiveType | ObjectType | TypeofReference | FunctionType | TypeParameter | ThisType;
 
@@ -326,7 +325,7 @@ export const create = {
         };
     },
 
-    objectType(members: InterfaceMember[]): ObjectType {
+    objectType(members: ObjectTypeMember[]): ObjectType {
         return {
             kind: "object",
             members
@@ -589,7 +588,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         return !!(needle & haystack);
     }
 
-    function printInterfaceMembers(members: InterfaceMember[]) {
+    function printObjectTypeMembers(members: ObjectTypeMember[]) {
         print('{');
         newline();
         indentLevel++;
@@ -600,7 +599,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         tab();
         print('}');
 
-        function printMember(member: InterfaceMember) {
+        function printMember(member: ObjectTypeMember) {
             switch (member.kind) {
                 case 'index-signature':
                     printDeclarationComments(member);
@@ -662,7 +661,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     newline();
                     return;
             }
-            never(member, `Unknown member kind ${(member as InterfaceMember).kind}`);
+            never(member, `Unknown member kind ${(member as ObjectTypeMember).kind}`);
         }
     }
 
@@ -688,7 +687,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     break;
 
                 case "object":
-                    printInterfaceMembers(e.members);
+                    printObjectTypeMembers(e.members);
                     break;
 
                 case "function-type":
@@ -750,7 +749,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                 first = false;
             }
         }
-        printInterfaceMembers(d.members);
+        printObjectTypeMembers(d.members);
         newline();
     }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,6 +42,13 @@ export interface IndexSignature {
     valueType: Type;
 }
 
+export interface CallSignature {
+    kind: "call-signature";
+    parameters: Parameter[];
+    returnType: Type;
+    typeParameters: TypeParameter[];
+}
+
 export interface MethodDeclaration extends DeclarationBase {
     kind: "method";
     name: string;
@@ -170,8 +177,8 @@ export type ThisType = "this";
 export type TypeReference = TopLevelDeclaration | NamedTypeReference | ArrayTypeReference | PrimitiveType;
 
 export type ObjectTypeReference = ClassDeclaration | InterfaceDeclaration;
-export type ObjectTypeMember = PropertyDeclaration | MethodDeclaration | IndexSignature;
-export type ClassMember = ObjectTypeMember | ConstructorDeclaration;
+export type ObjectTypeMember = PropertyDeclaration | MethodDeclaration | IndexSignature | CallSignature;
+export type ClassMember = PropertyDeclaration | MethodDeclaration | IndexSignature | ConstructorDeclaration;
 
 export type Type = TypeReference | UnionType | IntersectionType | PrimitiveType | ObjectType | TypeofReference | FunctionType | TypeParameter | ThisType;
 
@@ -258,6 +265,14 @@ export const create = {
             kind: "method",
             typeParameters: [],
             name, parameters, returnType, flags
+        };
+    },
+
+    callSignature(parameters: Parameter[], returnType: Type): CallSignature {
+        return {
+            kind: "call-signature",
+            typeParameters: [],
+            parameters, returnType
         };
     },
 
@@ -596,11 +611,29 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     print(';');
                     newline();
                     return;
+                case "call-signature": {
+                    printDeclarationComments(member);
+                    tab();
+                    writeTypeParameters(member.typeParameters);
+                    print("(");
+                    let first = true;
+                    for (const param of member.parameters) {
+                        if (!first) print(", ");
+                        first = false;
+                        print(param.name);
+                        print(": ");
+                        writeReference(param.type);
+                    }
+                    print("): ");
+                    writeReference(member.returnType);
+                    print(";");
+                    newline();
+                    return;
+                }
                 case 'method':
                     printDeclarationComments(member);
                     tab();
-                    let name = member.name ? quoteIfNeeded(member.name) : '';
-                    print(name);
+                    print(quoteIfNeeded(member.name));
                     if (hasFlag(member.flags, DeclarationFlags.Optional)) print('?');
                     print('(');
                     let first = true;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -599,7 +599,8 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                 case 'method':
                     printDeclarationComments(member);
                     tab();
-                    print(quoteIfNeeded(member.name));
+                    let name = member.name ? quoteIfNeeded(member.name) : '';
+                    print(name);
                     if (hasFlag(member.flags, DeclarationFlags.Optional)) print('?');
                     print('(');
                     let first = true;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -82,7 +82,7 @@ export interface ClassDeclaration extends DeclarationBase {
 export interface InterfaceDeclaration extends DeclarationBase {
     kind: "interface";
     name: string;
-    members: ObjectTypeMember[];
+    members: InterfaceMember[];
     baseTypes?: ObjectTypeReference[];
 }
 
@@ -130,7 +130,7 @@ export interface ModuleDeclaration extends DeclarationBase {
 
 export interface ObjectType {
     kind: "object";
-    members: ObjectTypeMember[];
+    members: InterfaceMember[];
 }
 
 export interface UnionType {
@@ -177,8 +177,9 @@ export type ThisType = "this";
 export type TypeReference = TopLevelDeclaration | NamedTypeReference | ArrayTypeReference | PrimitiveType;
 
 export type ObjectTypeReference = ClassDeclaration | InterfaceDeclaration;
-export type ObjectTypeMember = PropertyDeclaration | MethodDeclaration | IndexSignature | CallSignature;
-export type ClassMember = PropertyDeclaration | MethodDeclaration | IndexSignature | ConstructorDeclaration;
+export type ObjectTypeMember = PropertyDeclaration | MethodDeclaration | IndexSignature;
+export type InterfaceMember = ObjectTypeMember | CallSignature;
+export type ClassMember = ObjectTypeMember | ConstructorDeclaration;
 
 export type Type = TypeReference | UnionType | IntersectionType | PrimitiveType | ObjectType | TypeofReference | FunctionType | TypeParameter | ThisType;
 
@@ -325,7 +326,7 @@ export const create = {
         };
     },
 
-    objectType(members: ObjectTypeMember[]): ObjectType {
+    objectType(members: InterfaceMember[]): ObjectType {
         return {
             kind: "object",
             members
@@ -588,7 +589,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         return !!(needle & haystack);
     }
 
-    function printObjectTypeMembers(members: ObjectTypeMember[]) {
+    function printObjectTypeMembers(members: InterfaceMember[]) {
         print('{');
         newline();
         indentLevel++;
@@ -599,7 +600,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         tab();
         print('}');
 
-        function printMember(member: ObjectTypeMember) {
+        function printMember(member: InterfaceMember) {
             switch (member.kind) {
                 case 'index-signature':
                     printDeclarationComments(member);
@@ -661,7 +662,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     newline();
                     return;
             }
-            never(member, `Unknown member kind ${(member as ObjectTypeMember).kind}`);
+            never(member, `Unknown member kind ${(member as InterfaceMember).kind}`);
         }
     }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -589,7 +589,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         return !!(needle & haystack);
     }
 
-    function printObjectTypeMembers(members: InterfaceMember[]) {
+    function printInterfaceMembers(members: InterfaceMember[]) {
         print('{');
         newline();
         indentLevel++;
@@ -688,7 +688,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     break;
 
                 case "object":
-                    printObjectTypeMembers(e.members);
+                    printInterfaceMembers(e.members);
                     break;
 
                 case "function-type":
@@ -750,7 +750,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                 first = false;
             }
         }
-        printObjectTypeMembers(d.members);
+        printInterfaceMembers(d.members);
         newline();
     }
 


### PR DESCRIPTION
Currently, `dts-dom` generates bare function signatures like this:
```typescript
declare interface JQueryStatic {
    ""(): JQuery;
}
```
This PR fixes it to generate the signature without the quotes.
```typescript
declare interface JQueryStatic {
    (): JQuery;
}
```