### PR TITLE
Add support for generic type aliases

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -146,6 +146,7 @@ export interface TypeAliasDeclaration extends DeclarationBase {
     kind: "alias";
     name: string;
     type: Type;
+    typeParameters: TypeParameter[];
 }
 
 export interface ArrayTypeReference {
@@ -299,7 +300,8 @@ export const create = {
 
     alias(name: string, type: Type): TypeAliasDeclaration {
         return {
-            kind: "alias", name, type
+            kind: "alias", name, type,
+            typeParameters: []
         };
     },
 
@@ -860,7 +862,9 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
 
     function writeAlias(a: TypeAliasDeclaration) {
         printDeclarationComments(a);
-        startWithDeclareOrExport(`type ${a.name} = `, a.flags);
+        startWithDeclareOrExport(`type ${a.name}`, a.flags);
+        writeTypeParameters(a.typeParameters);
+        print(' = ');
         writeReference(a.type);
         print(';');
         newline();


### PR DESCRIPTION
Usage
```typescript
let thenable = dom.create.alias('Thenable', dom.create.namedTypeReference('PromiseLike<any>'));
thenable.typeParameters.push(dom.create.typeParameter('T'));
```