### PR TITLE
Properties with a function type can now be emitted as a method signature

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -649,7 +649,9 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     if ((config.preferMethodSignature === true) &&
                         (typeof member.type !== "string") &&
                         (member.type.kind === "function-type")) {
-                        const m = create.method(member.name, member.type.parameters, member.type.returnType);
+                        const m = create.method(member.name, member.type.parameters, member.type.returnType, member.flags);
+                        m.comment = member.comment;
+                        m.jsDocComment = member.jsDocComment;
                         printMember(m);
                         return;
                     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -213,6 +213,7 @@ export enum ParameterFlags {
 export const config = {
     wrapJsDocComments: true,
     outputEol: '\r\n',
+    preferMethodSignature: false,
 };
 
 export const create = {
@@ -645,6 +646,13 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     newline();
                     return;
                 case 'property':
+                    if ((config.preferMethodSignature === true) &&
+                        (typeof member.type !== "string") &&
+                        (member.type.kind === "function-type")) {
+                        const m = create.method(member.name, member.type.parameters, member.type.returnType);
+                        printMember(m);
+                        return;
+                    }
                     printDeclarationComments(member);
                     tab();
                     if (hasFlag(member.flags, DeclarationFlags.ReadOnly)) print('readonly ');


### PR DESCRIPTION
Added it under a flag (`config.preferMethodSignature`, default `false`).