### PR TITLE
fixed optional parameters in method

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -669,9 +669,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     for (const param of member.parameters) {
                         if (!first) print(', ');
                         first = false;
-                        print(param.name);
-                        print(': ');
-                        writeReference(param.type);
+			writeParameter(param);
                     }
                     print('): ');
                     writeReference(member.returnType);


### PR DESCRIPTION
#27  for example:
the method (`f`) of  interface (`i`) , when the parameters optional flag is set, it won't print the `?`

before
```ts
declare interface i {
    f(optional: number): void;
}
```
after
```ts
declare interface i {
    f(optional?: number): void;
}
```