### PR TITLE
Allow more top-level exports, add "import =", and add named exports

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -106,6 +106,12 @@ export interface ImportDefaultDeclaration extends DeclarationBase {
     from: string;
 }
 
+export interface ImportEqualsDeclaration extends DeclarationBase {
+    kind: "import=";
+    name: string;
+    from: string;
+}
+
 export interface NamespaceDeclaration extends DeclarationBase {
     kind: "namespace";
     name: string;
@@ -200,7 +206,7 @@ export type ClassMember = PropertyDeclaration | MethodDeclaration | IndexSignatu
 
 export type Type = TypeReference | UnionType | IntersectionType | PrimitiveType | ObjectType | TypeofReference | FunctionType | TypeParameter | ThisType;
 
-export type Import = ImportAllDeclaration | ImportDefaultDeclaration | ImportNamedDeclaration;
+export type Import = ImportAllDeclaration | ImportDefaultDeclaration | ImportNamedDeclaration | ImportEqualsDeclaration;
 
 export type NamespaceMember = InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | NamespaceDeclaration | ConstDeclaration | VariableDeclaration | FunctionDeclaration;
 export type ModuleMember = InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | NamespaceDeclaration | ConstDeclaration | VariableDeclaration | FunctionDeclaration | Import;
@@ -419,6 +425,14 @@ export const create = {
             name,
             as: typeof from !== 'undefined' ? as : undefined,
             from: typeof from !== 'undefined' ? from : as
+        };
+    },
+
+    importEquals(name: string, from: string): ImportEqualsDeclaration {
+        return {
+            kind: 'import=',
+            name,
+            from
         };
     },
 
@@ -1004,6 +1018,11 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         newline();
     }
 
+    function writeImportEquals(i: ImportEqualsDeclaration) {
+        start(`import ${i.name} = require('${i.from}');`);
+        newline();
+    }
+
     function writeEnum(e: EnumDeclaration) {
         printDeclarationComments(e);
         startWithDeclareOrExport(`${e.constant ? 'const ' : ''}enum ${e.name} {`, e.flags);
@@ -1062,6 +1081,8 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     return writeImportDefault(d);
                 case "importNamed":
                     return writeImportNamed(d);
+                case "import=":
+                    return writeImportEquals(d);
                 case "enum":
                     return writeEnum(d);
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -135,6 +135,12 @@ export interface ExportEqualsDeclaration extends DeclarationBase {
     target: string;
 }
 
+export interface ExportNameDeclaration extends DeclarationBase {
+    kind: "exportName";
+    name: string;
+    as?: string;
+}
+
 export interface ModuleDeclaration extends DeclarationBase {
     kind: "module";
     name: string;
@@ -210,7 +216,7 @@ export type Import = ImportAllDeclaration | ImportDefaultDeclaration | ImportNam
 
 export type NamespaceMember = InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | NamespaceDeclaration | ConstDeclaration | VariableDeclaration | FunctionDeclaration;
 export type ModuleMember = InterfaceDeclaration | TypeAliasDeclaration | ClassDeclaration | NamespaceDeclaration | ConstDeclaration | VariableDeclaration | FunctionDeclaration | Import;
-export type TopLevelDeclaration =  NamespaceMember | ExportEqualsDeclaration | ModuleDeclaration | EnumDeclaration | Import;
+export type TopLevelDeclaration =  NamespaceMember | ExportEqualsDeclaration | ExportNameDeclaration | ModuleDeclaration | EnumDeclaration | Import;
 
 export enum DeclarationFlags {
     None = 0,
@@ -392,6 +398,14 @@ export const create = {
         return {
             kind: 'export=',
             target
+        };
+    },
+
+    exportName(name: string, as?: string): ExportNameDeclaration {
+        return {
+            kind: "exportName",
+            name,
+            as
         };
     },
 
@@ -983,6 +997,15 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         newline();
     }
 
+    function writeExportName(e: ExportNameDeclaration) {
+        start(`export { ${e.name}`);
+        if (e.as) {
+            print(` as ${e.as}`);
+        }
+        print(` };`);
+        newline();
+    }
+
     function writeModule(m: ModuleDeclaration) {
         printDeclarationComments(m);
         startWithDeclareOrExport(`module '${m.name}' {`, m.flags);
@@ -1073,6 +1096,8 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     return writeAlias(d);
                 case "export=":
                     return writeExportEquals(d);
+                case "exportName":
+                    return writeExportName(d);
                 case "module":
                     return writeModule(d);
                 case "importAll":

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -230,22 +230,24 @@ export const config = {
 };
 
 export const create = {
-    interface(name: string): InterfaceDeclaration {
+    interface(name: string, flags = DeclarationFlags.None): InterfaceDeclaration {
         return {
             name,
             baseTypes: [],
             kind: "interface",
-            members: []
+            members: [],
+            flags
         };
     },
 
-    class(name: string): ClassDeclaration {
+    class(name: string, flags = DeclarationFlags.None): ClassDeclaration {
         return {
             kind: 'class',
             name,
             members: [],
             implements: [],
-            typeParameters: []
+            typeParameters: [],
+            flags
         };
     },
 
@@ -256,11 +258,12 @@ export const create = {
         };
     },
 
-    enum(name: string, constant: boolean = false): EnumDeclaration {
+    enum(name: string, constant: boolean = false, flags = DeclarationFlags.None): EnumDeclaration {
         return {
             kind: 'enum',
             name, constant,
-            members: []
+            members: [],
+            flags
         };
     },
 
@@ -295,11 +298,11 @@ export const create = {
         };
     },
 
-    function(name: string, parameters: Parameter[], returnType: Type): FunctionDeclaration {
+    function(name: string, parameters: Parameter[], returnType: Type, flags = DeclarationFlags.None): FunctionDeclaration {
         return {
             kind: "function",
             typeParameters: [],
-            name, parameters, returnType
+            name, parameters, returnType, flags
         };
     },
 
@@ -325,9 +328,9 @@ export const create = {
         };
     },
 
-    const(name: string, type: Type): ConstDeclaration {
+    const(name: string, type: Type, flags = DeclarationFlags.None): ConstDeclaration {
         return {
-            kind: "const", name, type
+            kind: "const", name, type, flags
         };
     },
 
@@ -337,10 +340,10 @@ export const create = {
         };
     },
 
-    alias(name: string, type: Type): TypeAliasDeclaration {
+    alias(name: string, type: Type, flags = DeclarationFlags.None): TypeAliasDeclaration {
         return {
             kind: "alias", name, type,
-            typeParameters: []
+            typeParameters: [], flags
         };
     },
 


### PR DESCRIPTION
Hey Ryan!  While building a TypeScript declaration generator based on `dts-dom`, I found a few missing pieces and added them to the project.  Namely:

* Setting exports directly in `dom.create.{interface,class,enum,function,const,alias}` is now possible, e.g. `dom.create.class("foo", DeclarationFlags.Export);`
* The TypeScript-specific `import = require("some-package");` syntax has been added
* Exporting already-declared properties is now supported, e.g. `export { Foo };`

I've tested these all in practice, but haven't added samples yet because I didn't want to complicate the ones you've got.  If you'd like example usages for the documentation, please let me know!  I'd be happy to add some 😃 