### PR TITLE
Wrap function type in parentheses

### DIFF
--- a/lib/__tests__/__snapshots__/func.test.ts.snap
+++ b/lib/__tests__/__snapshots__/func.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an emitted function type matches the snapshot 1`] = `
+"declare type testFunction = (...args: any[])=>any;
+
+"
+`;

--- a/lib/__tests__/__snapshots__/union.test.ts.snap
+++ b/lib/__tests__/__snapshots__/union.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an emitted union type with a function and a string matches the snapshot 1`] = `
+"declare type testUnion = (...args: any[])=>any | string;
+
+"
+`;

--- a/lib/__tests__/__snapshots__/union.test.ts.snap
+++ b/lib/__tests__/__snapshots__/union.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`an emitted union type with a function and a string matches the snapshot 1`] = `
-"declare type testUnion = (...args: any[])=>any | string;
+"declare type testUnion = ((...args: any[])=>any) | string;
 
 "
 `;

--- a/lib/__tests__/func.test.ts
+++ b/lib/__tests__/func.test.ts
@@ -1,0 +1,13 @@
+import {ParameterFlags, create, emit} from "../index"
+
+describe("an emitted function type", () => {
+    it("matches the snapshot", () => {
+        const parameters = [
+            create.parameter('args', create.array('any'), ParameterFlags.Rest)
+        ];
+        const functionType = create.functionType(parameters, 'any');
+        const typeAlias = create.alias('testFunction', functionType);
+
+        expect(emit(typeAlias)).toMatchSnapshot();
+    });
+});

--- a/lib/__tests__/union.test.ts
+++ b/lib/__tests__/union.test.ts
@@ -1,0 +1,16 @@
+import {ParameterFlags, create, emit} from "../index"
+
+describe("an emitted union type", () => {
+    describe("with a function and a string", () => {
+        it("matches the snapshot", () => {
+            const parameters = [
+                create.parameter('args', create.array('any'), ParameterFlags.Rest)
+            ];
+            const functionType = create.functionType(parameters, 'any');
+            const union = create.union([functionType, 'string']);
+            const typeAlias = create.alias('testUnion', union);
+
+            expect(emit(typeAlias)).toMatchSnapshot();
+        });
+    });
+});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -848,11 +848,15 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
     }
 
     function writeFunctionType(f: FunctionType) {
+        // we wrap type in () here to make sure it works nicely in unions
+        // and other cases
+        print('(');
         print('(');
         writeDelimited(f.parameters, ', ', writeParameter);
         print(')');
         print('=>');
         writeReference(f.returnType);
+        print(')');
     }
 
     function writeFunction(f: FunctionDeclaration) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -749,6 +749,16 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
         }
     }
 
+    function writeUnionReference(d: Type) {
+        if (typeof d !== "string" && d.kind === "function-type") {
+            print('(')
+            writeReference(d)
+            print(')')
+        } else {
+            writeReference(d)
+        }
+    }
+
     function writeReference(d: Type) {
         if (typeof d === 'string') {
             print(d);
@@ -789,7 +799,7 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
                     break;
 
                 case "union":
-                    writeDelimited(e.members, ' | ', writeReference);
+                    writeDelimited(e.members, ' | ', writeUnionReference);
                     break;
 
                 case "typeof":
@@ -848,15 +858,11 @@ export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.Non
     }
 
     function writeFunctionType(f: FunctionType) {
-        // we wrap type in () here to make sure it works nicely in unions
-        // and other cases
-        print('(');
         print('(');
         writeDelimited(f.parameters, ', ', writeParameter);
         print(')');
         print('=>');
         writeReference(f.returnType);
-        print(')');
     }
 
     function writeFunction(f: FunctionDeclaration) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,7 @@
 	],
     "compilerOptions": {
         "types": [
-            "@types/node",
-            "@types/mocha",
-            "@types/chai"
+            "@types/node"
         ],
 
         "module": "commonjs",


### PR DESCRIPTION
Based on discussion in https://github.com/KnisterPeter/react-to-typescript-definitions/pull/465

I cherry-picked @KingHenne's [commit](https://github.com/KingHenne/dts-dom/commit/31bf2bf8aceb1dfa89622767555544a1dd106054) and adjusted the implementation (two more `print`'s in func declaration)

\* While installing deps I also realized that `@types/mocha @types/chai` were configured in `tsconfg` but not really specified and installed with the dependencies, thus removed it (here jest is used, not mocha)