### PR TITLE
Add support for triple slash directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,26 @@ declare namespace SomeNamespace {
 # Version History
 
 ## 2.0 (not yet released)
- * **New Functionality**: Added the ability to emit triple-slash-references #40
- * **Breaking Change**: Changed the second parameter of `emit` from `ContextFlags` to `EmitOptions` #40
-```ts
-// 1.0
-const s = emit(tree, ContextFlags.Module);
-// 2.0
-const s = emit(tree, { rootFlags: ContextFlags.Module });
-```
+ * **New Functionality**: Added the ability to emit [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) #39
+    ```ts
+    const tripleSlashDirectives = [create.tripleSlashReferenceTypesDirective("react")];
+    const returnType = create.namedTypeReference('JSX.Element');
+    const component = create.function('Component', [], returnType, DeclarationFlags.Export);
+    const s = emit(component, { tripleSlashDirectives });
+    ```
+
+    The value of `s` is:
+    ```ts
+    /// <reference types="react" />
+    export function Component(): JSX.Element;
+    ```
+ * **Breaking Change**: Changed the second parameter of `emit` from `ContextFlags` to `EmitOptions` #39
+    ```ts
+    // 1.0
+    const s = emit(tree, ContextFlags.Module);
+    // 2.0
+    const s = emit(tree, { rootFlags: ContextFlags.Module });
+    ```
 
 ## 1.0
 

--- a/lib/__tests__/__snapshots__/func.test.ts.snap
+++ b/lib/__tests__/__snapshots__/func.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`an emitted function type matches the snapshot 1`] = `
-"declare type testFunction = (...args: any[])=>any;
+declare type testFunction = (...args: any[])=>any;
 
-"
+
 `;

--- a/lib/__tests__/__snapshots__/tripleSlashDirective.test.ts.snap
+++ b/lib/__tests__/__snapshots__/tripleSlashDirective.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an emitted module with triple slash directives matches the snapshot 1`] = `
+/// <reference path="./test" />
+/// <reference types="test" />
+/// <reference no-default-lib="true" />
+/// <amd-module />
+/// <amd-module name="test" />
+declare module 'test' {
+}
+
+
+`;
+
+exports[`an emitted module without triple slash directives matches the snapshot 1`] = `
+declare module 'test' {
+}
+
+
+`;

--- a/lib/__tests__/__snapshots__/union.test.ts.snap
+++ b/lib/__tests__/__snapshots__/union.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`an emitted union type with a function and a string matches the snapshot 1`] = `
-"declare type testUnion = ((...args: any[])=>any) | string;
+declare type testUnion = ((...args: any[])=>any) | string;
 
-"
+
 `;

--- a/lib/__tests__/__snapshots__/variableDeclaration.test.ts.snap
+++ b/lib/__tests__/__snapshots__/variableDeclaration.test.ts.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`an emitted variable definition in a module matches the snapshot 1`] = `
-"declare module 'myTestModule' {
+declare module 'myTestModule' {
     declare var myVar: string | boolean;
 
 }
 
-"
+
 `;
 
 exports[`an emitted variable definition in a namespace matches the snapshot 1`] = `
-"declare namespace myTestNamespace {
+declare namespace myTestNamespace {
     var myVar: string | boolean;
 
 }
 
-"
+
 `;
 
 exports[`an emitted variable definition matches the snapshot 1`] = `
-"declare var myVar: string | boolean;
+declare var myVar: string | boolean;
 
-"
+
 `;

--- a/lib/__tests__/string-snapshot-serializer.js
+++ b/lib/__tests__/string-snapshot-serializer.js
@@ -1,0 +1,9 @@
+module.exports = {
+    print(val, serialize, indent) {
+        return val;
+    },
+
+    test(val) {
+        return typeof val === "string";
+    },
+};

--- a/lib/__tests__/tripleSlashDirective.test.ts
+++ b/lib/__tests__/tripleSlashDirective.test.ts
@@ -11,8 +11,9 @@ describe("an emitted module with triple slash directives", () => {
         tripleSlashDirectives.push(create.tripleSlashAmdModuleDirective("test"));
 
         const module = create.module("test");
+        const emitOptions = {rootFlags: ContextFlags.Module, tripleSlashDirectives};
 
-        expect(emit(module, ContextFlags.Module, tripleSlashDirectives)).toMatchSnapshot();
+        expect(emit(module, emitOptions)).toMatchSnapshot();
     });
 });
 
@@ -20,6 +21,6 @@ describe("an emitted module without triple slash directives", () => {
     it("matches the snapshot", () => {
         const module = create.module("test");
 
-        expect(emit(module, ContextFlags.Module)).toMatchSnapshot();
+        expect(emit(module, {rootFlags: ContextFlags.Module})).toMatchSnapshot();
     });
 });

--- a/lib/__tests__/tripleSlashDirective.test.ts
+++ b/lib/__tests__/tripleSlashDirective.test.ts
@@ -1,0 +1,25 @@
+import {ContextFlags, TripleSlashDirective, create, emit} from "../index"
+
+describe("an emitted module with triple slash directives", () => {
+    it("matches the snapshot", () => {
+        const tripleSlashDirectives: TripleSlashDirective[] = [];
+
+        tripleSlashDirectives.push(create.tripleSlashReferencePathDirective("./test"));
+        tripleSlashDirectives.push(create.tripleSlashReferenceTypesDirective("test"));
+        tripleSlashDirectives.push(create.tripleSlashReferenceNoDefaultLibDirective());
+        tripleSlashDirectives.push(create.tripleSlashAmdModuleDirective());
+        tripleSlashDirectives.push(create.tripleSlashAmdModuleDirective("test"));
+
+        const module = create.module("test");
+
+        expect(emit(module, ContextFlags.Module, tripleSlashDirectives)).toMatchSnapshot();
+    });
+});
+
+describe("an emitted module without triple slash directives", () => {
+    it("matches the snapshot", () => {
+        const module = create.module("test");
+
+        expect(emit(module, ContextFlags.Module)).toMatchSnapshot();
+    });
+});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -597,7 +597,12 @@ export function never(x: never, err: string): never {
     throw new Error(err);
 }
 
-export function emit(rootDecl: TopLevelDeclaration, rootFlags = ContextFlags.None, tripleSlashDirectives: TripleSlashDirective[] = []): string {
+export interface EmitOptions {
+    rootFlags?: ContextFlags;
+    tripleSlashDirectives?: TripleSlashDirective[];
+}
+
+export function emit(rootDecl: TopLevelDeclaration, { rootFlags = ContextFlags.None, tripleSlashDirectives = [] }: EmitOptions = {}): string {
     let output = "";
     let indentLevel = 0;
     let contextStack: ContextFlags[] = [rootFlags];

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "mapCoverage": true,
     "collectCoverageFrom": [
       "lib/**/*.ts"
+    ],
+    "snapshotSerializers": [
+      "./lib/__tests__/string-snapshot-serializer"
     ]
   }
 }


### PR DESCRIPTION
An array of [triple slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html) can be passed to the emit function. The triple slash directives will be printed before everything else.

@RyanCavanaugh Let me know if you think passing them as third argument to `dom.emit` is not a good idea.

I would have preferred changing the second param of `dom.emit` to `options: EmitOptions = { rootFlags = ContextFlags.None, tripleSlashDirectives = [] }`. But that would obviously be a breaking change.

I also considered making `TripleSlashDirective` a `TopLevelDeclaration`. First of all, a triple slash directive is not a declaration. Secondly, you would then have to manually stitch the return values of multiple `dom.emit` calls together. And it wouldn't be guaranteed that a triple slash directive is not followed by a declaration.

Note: This PR also introduces a custom snapshot serializer for strings, to avoid ugly escaped double quotes in the snapshots.