### PR TITLE
Fix printing of enum members with falsy values

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1181,7 +1181,7 @@ export function emit(rootDecl: TopLevelDeclaration, { rootFlags = ContextFlags.N
         printDeclarationComments(e);
         start(e.name);
 
-        if (e.value) {
+        if (e.value !== undefined) {
             if (typeof e.value === 'string') {
                 print(` = "${e.value}"`);
             } else {


### PR DESCRIPTION
Before it was impossible to declare enum member with a value of `0`.