### PR TITLE
Add generic type arguments to NamedTypeReference

### DIFF
--- a/lib/__tests__/__snapshots__/namedTypeReference.test.ts.snap
+++ b/lib/__tests__/__snapshots__/namedTypeReference.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an emitted named reference without type arguments 1`] = `
+type Alias = MyInterface;
+
+
+`;
+
+exports[`an emitted named reference with single type argument 1`] = `
+type Alias = Promise<string>;
+
+
+`;
+
+exports[`an emitted named reference with multiple type arguments 1`] = `
+type Alias = Generator<string, number>;
+
+
+`;

--- a/lib/__tests__/__snapshots__/namedTypeReference.test.ts.snap
+++ b/lib/__tests__/__snapshots__/namedTypeReference.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`an emitted named reference without type arguments 1`] = `
-type Alias = MyInterface;
+exports[`an emitted named reference with multiple type arguments matches the snapshot 1`] = `
+declare type Alias = Generator<string, number>;
 
 
 `;
 
-exports[`an emitted named reference with single type argument 1`] = `
-type Alias = Promise<string>;
+exports[`an emitted named reference with single type argument matches the snapshot 1`] = `
+declare type Alias = Promise<string>;
 
 
 `;
 
-exports[`an emitted named reference with multiple type arguments 1`] = `
-type Alias = Generator<string, number>;
+exports[`an emitted named reference without type arguments matches the snapshot 1`] = `
+declare type Alias = MyInterface;
 
 
 `;

--- a/lib/__tests__/namedTypeReference.test.ts
+++ b/lib/__tests__/namedTypeReference.test.ts
@@ -1,0 +1,39 @@
+import * as dom from "../index"
+
+describe("an emitted named reference", () => {
+    describe("without type arguments", () => {
+        it("matches the snapshot", () => {
+            let typeReference = dom.create.namedTypeReference(
+                "MyInterface"
+            );
+            let alias = dom.create.alias('Alias', typeReference);
+
+            expect(dom.emit(alias)).toMatchSnapshot();
+        });
+    });
+
+    describe("with single type argument", () => {
+        it("matches the snapshot", () => {
+            let typeReference = dom.create.namedTypeReference(
+                "Promise"
+            );
+            typeReference.typeArguments.push(dom.type.string);
+            let alias = dom.create.alias('Alias', typeReference);
+
+            expect(dom.emit(alias)).toMatchSnapshot();
+        });
+    });
+    
+    describe("with multiple type arguments", () => {
+        it("matches the snapshot", () => {
+            let typeReference = dom.create.namedTypeReference(
+                "Generator"
+            );
+            typeReference.typeArguments.push(dom.type.string);
+            typeReference.typeArguments.push(dom.type.number);
+            let alias = dom.create.alias('Alias', typeReference);
+
+            expect(dom.emit(alias)).toMatchSnapshot();
+        });
+    });
+});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -426,7 +426,8 @@ export const create = {
     namedTypeReference(name: string): NamedTypeReference {
         return {
             kind: 'name',
-            name
+            name,
+            typeArguments: []
         };
     },
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -195,6 +195,7 @@ export interface ArrayTypeReference {
 export interface NamedTypeReference {
     kind: "name";
     name: string;
+    typeArguments: Type[];
 }
 
 export interface TypeofReference {
@@ -861,9 +862,13 @@ export function emit(rootDecl: TopLevelDeclaration, { rootFlags = ContextFlags.N
                 case "type-parameter":
                 case "class":
                 case "interface":
-                case "name":
                 case "alias":
                     print(e.name);
+                    break;
+
+                case "name":
+                    print(e.name);
+                    writeTypeArguments(e.typeArguments);
                     break;
 
                 case "array":
@@ -936,6 +941,24 @@ export function emit(rootDecl: TopLevelDeclaration, { rootFlags = ContextFlags.N
               print(' = ');
               writeReference(p.defaultType);
             }
+
+            first = false;
+        }
+
+        print('>');
+    }
+    
+    function writeTypeArguments(args: Type[]) {
+        if (args.length === 0) return;
+
+        print('<');
+
+        let first = true;
+
+        for (const p of args) {
+            if (!first) print(', ');
+
+            writeReference(p);
 
             first = false;
         }


### PR DESCRIPTION
NamedTypeReference can have one or more type arguments.  For example, `Promise<string>`.

Implements #45.