### PR TITLE
Add interface type params and update TypeParam type definition

### DIFF
--- a/lib/__tests__/__snapshots__/interface.test.ts.snap
+++ b/lib/__tests__/__snapshots__/interface.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an emitted interface empty matches the snapshot 1`] = `
+declare interface Interface {
+}
+
+
+`;
+
+exports[`an emitted interface with type parameters matches the snapshot 1`] = `
+declare interface Interface<T1, T2 extends object, T3 extends BaseFoo> {
+}
+
+
+`;

--- a/lib/__tests__/interface.test.ts
+++ b/lib/__tests__/interface.test.ts
@@ -1,0 +1,24 @@
+import * as dom from "../index";
+
+describe("an emitted interface", () => {
+  describe("empty", () => {
+    it("matches the snapshot", () => {
+      let iface = dom.create.interface("Interface");
+
+      expect(dom.emit(iface)).toMatchSnapshot();
+    });
+  });
+  describe("with type parameters", () => {
+    it("matches the snapshot", () => {
+      let clazz = dom.create.class("BaseFoo");
+      let iface = dom.create.interface("Interface");
+      iface.typeParameters.push(dom.create.typeParameter("T1"));
+      iface.typeParameters.push(
+        dom.create.typeParameter("T2", dom.type.object)
+      );
+      iface.typeParameters.push(dom.create.typeParameter("T3", clazz));
+
+      expect(dom.emit(iface)).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
Interfaces can have type parameters, which can extend other type parameters from the same parameter list, type literals, or type refrences.

With this PR,

```typescript
let clazz = dom.create.class("BaseFoo");
let iface = dom.create.interface("Interface");
iface.typeParameters.push(dom.create.typeParameter("T1"));
iface.typeParameters.push(
  dom.create.typeParameter("T2", dom.type.object)
);
iface.typeParameters.push(dom.create.typeParameter("T3", clazz));
```

will generate

```typescript
declare interface Interface<T1, T2 extends object, T3 extends BaseFoo> {
}

```
(test case added as snapshot test).

Grammar reference:
- InterfaceDeclaration https://github.com/microsoft/TypeScript/blob/master/doc/spec.md#71-interface-declarations
- TypeParameters https://github.com/microsoft/TypeScript/blob/master/doc/spec.md#a1-types