### PR TITLE
fix call-signature parameter flags

### DIFF
--- a/lib/__tests__/__snapshots__/iface.test.ts.snap
+++ b/lib/__tests__/__snapshots__/iface.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`an interface type with call signature matches the snapshot 1`] = `
+declare interface iface {
+    (first?: string, ...second: any[]): string;
+}
+
+
+`;

--- a/lib/__tests__/iface.test.ts
+++ b/lib/__tests__/iface.test.ts
@@ -1,0 +1,18 @@
+import {ParameterFlags, create, emit, type} from "../index"
+
+describe("an interface type", () => {
+    describe("with call signature", () => {
+        it("matches the snapshot", () => {
+            const parameters = [
+                create.parameter('first', type.string, ParameterFlags.Optional),
+                create.parameter('second', create.array('any'), ParameterFlags.Rest)
+            ];
+            const cs = create.callSignature(parameters, type.string);
+            const iface = create.interface('iface');
+          
+            iface.members.push(cs);
+          
+            expect(emit(iface)).toMatchSnapshot();
+        });
+    });
+});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -796,14 +796,7 @@ export function emit(rootDecl: TopLevelDeclaration, { rootFlags = ContextFlags.N
                     tab();
                     writeTypeParameters(member.typeParameters);
                     print("(");
-                    let first = true;
-                    for (const param of member.parameters) {
-                        if (!first) print(", ");
-                        first = false;
-                        print(param.name);
-                        print(": ");
-                        writeReference(param.type);
-                    }
+                    writeDelimited(member.parameters, ', ', writeParameter);
                     print("): ");
                     writeReference(member.returnType);
                     print(";");


### PR DESCRIPTION
Fix so that parameter flags are printed for call-signature:

**Before**
```ts
declare interface iface {
    (first: string, second: any[]): string;
}
```

**After**
```ts
declare interface iface {
    (first?: string, ...second: any[]): string;
}
```