### PR TITLE
Added `bigint` and `symbol` to PrimitiveType

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -239,7 +239,7 @@ export interface TripleSlashAmdModuleDirective {
     name?: string;
 }
 
-export type PrimitiveType = "string" | "number" | "bigint" | "boolean" | "any" | "unknown" | "void" | "object" | "null" | "undefined" | "true" | "false" | StringLiteral | NumberLiteral;
+export type PrimitiveType = "string" | "number" |  "bigint" | "boolean" | "any" | "unknown" | "void" | "object" | "symbol" | "null" | "undefined" | "true" | "false" | StringLiteral | NumberLiteral;
 
 export function isPrimitiveType(x: Type): x is PrimitiveType {
   switch (x) {
@@ -251,6 +251,7 @@ export function isPrimitiveType(x: Type): x is PrimitiveType {
       case "unknown":
       case "void":
       case "object":
+      case "symbol":
       case "null":
       case "undefined":
       case "true":
@@ -618,6 +619,7 @@ export const type = {
     unknown: <PrimitiveType>"unknown",
     void: <PrimitiveType>"void",
     object: <PrimitiveType>"object",
+    symbol: <PrimitiveType>"symbol",
     null: <PrimitiveType>"null",
     undefined: <PrimitiveType>"undefined",
     true: <PrimitiveType>"true",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -239,12 +239,13 @@ export interface TripleSlashAmdModuleDirective {
     name?: string;
 }
 
-export type PrimitiveType = "string" | "number" | "boolean" | "any" | "unknown" | "void" | "object" | "null" | "undefined" | "true" | "false" | StringLiteral | NumberLiteral;
+export type PrimitiveType = "string" | "number" | "bigint" | "boolean" | "any" | "unknown" | "void" | "object" | "null" | "undefined" | "true" | "false" | StringLiteral | NumberLiteral;
 
 export function isPrimitiveType(x: Type): x is PrimitiveType {
   switch (x) {
       case "string":
       case "number":
+      case "bigint":
       case "boolean":
       case "any":
       case "unknown":
@@ -611,6 +612,7 @@ export const type = {
     },
     string: <PrimitiveType>"string",
     number: <PrimitiveType>"number",
+    bigint: <PrimitiveType>"bigint",
     boolean: <PrimitiveType>"boolean",
     any: <PrimitiveType>"any",
     unknown: <PrimitiveType>"unknown",


### PR DESCRIPTION
[bigint](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) and [symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) was missing from the PrimitiveType definition.